### PR TITLE
Update ReadOnlyWriteOnlyTest.java

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ReadOnlyWriteOnlyTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ReadOnlyWriteOnlyTest.java
@@ -73,27 +73,12 @@ public class ReadOnlyWriteOnlyTest {
         final Settings settings = TestUtils.settings();
         settings.generateReadonlyAndWriteonlyJSDocTags = true;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ReadOnlyWriteOnlyUser.class));
-        final String expected = "\n"
-                + "interface ReadOnlyWriteOnlyUser {\n"
-                + "    name: string;\n"
-                + "    /**\n"
-                + "     * @readonly\n"
-                + "     */\n"
-                + "    id1: string;\n"
-                + "    /**\n"
-                + "     * @writeonly\n"
-                + "     */\n"
-                + "    password1: string;\n"
-                + "    /**\n"
-                + "     * @readonly\n"
-                + "     */\n"
-                + "    id2: string;\n"
-                + "    /**\n"
-                + "     * @writeonly\n"
-                + "     */\n"
-                + "    password2: string;\n"
-                + "}\n";
-        Assertions.assertEquals(expected, output);
+        String expected1 = "    name: string;\n";
+        String expected2 = "    /**\n" + "     * @readonly\n" + "     */\n" + "    id1: string;\n";
+        String expected3 = "    /**\n" + "     * @writeonly\n" + "     */\n" + "    password1: string;\n";
+        String expected4 = "    /**\n" + "     * @readonly\n" + "     */\n" + "    id2: string;\n";
+        String expected5 = "    /**\n" + "     * @writeonly\n" + "     */\n" + "    password2: string;\n";
+        Assertions.assertTrue(output.length() == 269 && output.substring(0,35).equals("\n" + "interface ReadOnlyWriteOnlyUser {\n") && output.substring(267,269).equals("}\n") && output.contains(expected1) && output.contains(expected2) && output.contains(expected3) && output.contains(expected4) && output.contains(expected5));
     }
 
 }


### PR DESCRIPTION
**What this pull request does**
This pull request fixes the flaky test ReadOnlyWriteOnlyTest.test. The test passes sometimes and fails other times because the Properties class in Java stores a hashtable of properties which is unordered, while the test assumes a specific order.

**Why the test is flaky**
The error in this specific test can be traced back to TypeScriptGenerator.generateTypeScript, ModelParser.parseModel, Jackson2Parser.parseBean, and finally Jackson2Parser.getProps. The method Jackson2Parser.getProps returns a list of properties which is unordered, according to the documentation for java.util.Properties. However, in ReadOnlyWriteOnlyTest.test, final String expected has a fixed order.

**How the test was changed**
The expected string and assertEquals Assertion were replaced with an assertTrue Assertion. The new Assertion takes into account all of the possible permutations of the properties.

**Output from testing**
Running ReadOnlyWriteOnlyTest.test with NonDex shows the test failing:
`mvn -e -pl typescript-generator-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=cz.habarta.typescript.generator.ReadOnlyWriteOnlyTest#test`

[ERROR] cz.habarta.typescript.generator.ReadOnlyWriteOnlyTest.test  Time elapsed: 0.413 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: 
expected: <
interface ReadOnlyWriteOnlyUser {
    name: string;
    /**
     * @readonly
     */
    id1: string;
    /**
     * @writeonly
     */
    password1: string;
    /**
     * @readonly
     */
    id2: string;
    /**
     * @writeonly
     */
    password2: string;
}
> but was: <
interface ReadOnlyWriteOnlyUser {
    name: string;
    /**
     * @writeonly
     */
    password1: string;
    /**
     * @readonly
     */
    id1: string;
    /**
     * @readonly
     */
    id2: string;
    /**
     * @writeonly
     */
    password2: string;
}
>